### PR TITLE
https://github.com/nrem/pewi/issues/57

### DIFF
--- a/index.html
+++ b/index.html
@@ -169,7 +169,7 @@
         <section id="pfeature-toolbar" class="menu-background">
             <ul class="list-vertical">
                 <li>
-                    <div><img src="images/icons/navigation/Icon_Topography.svg" id="topo" class="selectable-pfeature" title="Topography"></div>
+                    <div><img src="images/icons/navigation/Icon_Topography.svg" id="topo" class="selectable-pfeature" title="Topographic Relief"></div>
                 </li>
                 <li>
                     <div><img src="images/icons/navigation/Icon_Flood_Frequency.svg" id="flood" class="selectable-pfeature" title="Flood Frequency"></div>


### PR DESCRIPTION
Fixed issue #57 by changing the text from "Topography" to "Topographic Relief" that appears when hovering over the Topographic Relief icon.
